### PR TITLE
(1) Recbole 1.1.1 actually requires `torch>=1.10.0` instead of `torch>=1.7.0` and (2) compatibility for `numpy>=2.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 ```
 recbole==1.1.1
 pyg>=2.0.4
-pytorch>=1.7.0
+pytorch>=1.10.0
 python>=3.7.0
 ```
 

--- a/recbole_gnn/config.py
+++ b/recbole_gnn/config.py
@@ -23,14 +23,14 @@ class Config(RecBole_Config):
 
     def compatibility_settings(self):
         import numpy as np
-        np.bool = np.bool_
-        np.int = np.int_
-        np.float = np.float_
-        np.complex = np.complex_
-        np.object = np.object_
-        np.str = np.str_
+        np.bool = bool
+        np.int = int
+        np.float = float
+        np.complex = complex
+        np.object = object
+        np.str = str
         np.long = np.int_
-        np.unicode = np.unicode_
+        np.unicode = np.str_
 
     def _get_model_and_dataset(self, model, dataset):
 


### PR DESCRIPTION
(1) Recbole 1.1.1 actually requires `torch>=1.10.0` instead of `torch>=1.7.0` as mentioned in the current README file: `recbole 1.1.1 requires torch>=1.10.0, but you have torch 1.9.0 which is incompatible.`

(2) The existing compatibility code does not work for latest numpy versions `numpy>=2.0`.